### PR TITLE
Criação do raspador da cidade de juiz de fora (REFEITO)

### DIFF
--- a/backend/webscrapy/minas_de_cultura_scrapy/minas_de_cultura_scrapy/spiders/juiz_de_fora.py
+++ b/backend/webscrapy/minas_de_cultura_scrapy/minas_de_cultura_scrapy/spiders/juiz_de_fora.py
@@ -1,0 +1,92 @@
+import scrapy
+import pdfplumber
+import json
+import os
+
+class JuizDeForaSpider(scrapy.Spider):
+    name = 'juiz_de_fora'
+
+    def __init__(self, ano=None, mes=None, *args, **kwargs):
+        super(JuizDeForaSpider, self).__init__(*args, **kwargs)
+        if ano is None or mes is None:
+            raise ValueError("Ano e mês devem ser fornecidos")
+        if not (22 <= int(ano) <= 24):
+            raise ValueError("Ano deve estar entre 22 e 24")
+        if not (1 <= int(mes) <= 12):
+            raise ValueError("Mês deve estar entre 1 e 12")
+
+        self.ano = ano
+        self.mes = mes.zfill(2)
+        self.start_urls = [f'http://www.pjf.mg.gov.br/transparencia/despesas_publicas/mensal_consolidada/arquivos/pdf/{ano}{self.mes}.pdf']
+
+    def start_requests(self):
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, Gecko) Chrome/91.0.4472.124 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.5',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Connection': 'keep-alive',
+            'Upgrade-Insecure-Requests': '1',
+            'TE': 'Trailers',
+        }
+        yield scrapy.Request(self.start_urls[0], headers=headers, callback=self.parse)
+
+    def parse(self, response):
+        if response.status == 200:
+            self.log(f'Successfully accessed the PDF: {response.url}')
+            path = f'despesas_{self.ano}{self.mes}.pdf'
+            with open(path, 'wb') as f:
+                f.write(response.body)
+            self.log(f'Successfully downloaded the PDF to {path}')
+            self.process_pdf(path)
+        else:
+            self.log(f'Failed to access the PDF: {response.url} with status code {response.status}')
+
+    def process_pdf(self, path):
+        try:
+            with pdfplumber.open(path) as pdf:
+                first_page = pdf.pages[0]
+                table = first_page.extract_table()
+                if table:
+                    data = []
+                    headers = table[0]
+                    keywords = {
+                        "FUNALFA": "Fundação Cultural Alfredo Ferreira Lage",
+                        "SETUR": "Secretaria de Turismo",
+                        "FUMAPE": "Fundo Municipal de Apoio ao Esporte",
+                        "FUMTUR": "Fundo Municipal de Turismo",
+                        "FMC": "Fundo Municipal de Cultura",
+                        "MAPRO": "Manutenção de Programas"
+                    }
+                    for row in table[1:]:
+                        for keyword, full_name in keywords.items():
+                            if keyword in row[0]:
+                                entry = {
+                                    "Sigla": keyword,
+                                    "Unidade administrativa": full_name,
+                                    "Valor empenhado": row[2],
+                                    "Valor liquidado": row[3],
+                                    "Valor pago": row[4],
+                                    "ano": self.ano,
+                                    "mes": self.mes
+                                }
+                                data.append(entry)
+                    
+                    # Save data as JSON
+                    json_path = 'despesas.json'
+                    if os.path.exists(json_path):
+                        with open(json_path, 'r', encoding='utf-8') as json_file:
+                            existing_data = json.load(json_file)
+                    else:
+                        existing_data = []
+
+                    existing_data.extend(data)
+
+                    with open(json_path, 'w', encoding='utf-8') as json_file:
+                        json.dump(existing_data, json_file, ensure_ascii=False, indent=4)
+                    self.log(f'Successfully saved data to {json_path}')
+        except Exception as e:
+            self.log(f'Error processing PDF: {e}')
+
+        # Clean up the downloaded PDF
+        os.remove(path)

--- a/docs/Como executar/Tutorial_scrapy.md
+++ b/docs/Como executar/Tutorial_scrapy.md
@@ -63,8 +63,9 @@ cd webscrapy/minas_de_cultura_scrapy
 ```
 
 Execução do crawler:
+Os valores de ano foram definidos para funcionar entre 2022 até 2024 e os meses se iniciam sendo 01 até o 12.
 ```
-scrapy crawl prototipo_spider -o resultado.json
+scrapy crawl juiz_de_fora -a ano=xx -a mes=xx
 ```
 
 passando os parâmetros no final o resultado será armazenado como json em um arquivo nomeado resultado.
@@ -72,7 +73,7 @@ passando os parâmetros no final o resultado será armazenado como json em um ar
 ## Passo 7: Resultado da busca
 Para vizualizar o resultado basta dar o comando:
 ```
-cat resultado.json
+cat despesas.json
 ```
 
 ## Passo 8: Desativação do Ambiente Virtual


### PR DESCRIPTION
# [Raspador scrapy juiz de fora]

## Descrição
Este PR implementa o raspador web utilizando Scrapy para coletar dados de gastos públicos voltados à cultura no município de Juiz de Fora. O raspador foi desenvolvido para automatizar a navegação e extração de dados das páginas web específicas, contribuindo para o projeto de transparência de gastos públicos no estado de Minas Gerais.

Para testar as alterações faça` git checkout raspadores` e navegue até a pasta `cd webscrapy/minas_de_cultura_scrapy` e então basta fazer os testes nescessários e correções. 

Parra rodar o script acesse a página do webscrapy e rode o comando no terminal, o ano pode variar de 2022 até 2024 e os meses se iniciam em 1 e terminam em 12
`scrapy crawl juiz_de_fora -a ano=23 -a mes=02`

## Checklist
- [x] As alterações foram testadas localmente.
- [x] As alterações não introduzem novos problemas ou erros.
- [x] Os nomes das variáveis, funções e comentários estão em conformidade com as diretrizes de estilo do projeto.
- [ ] Os testes foram adicionados ou atualizados para refletir as alterações feitas.
- [x] A documentação foi atualizada, se necessário.
- [ ] Todos os conflitos foram resolvidos e o código está pronto para ser revisado e mesclado.

## Notas Adicionais
As informações do scrapy estão sendo salvas em um arquivo chamado "despesas.json", segue abaixo uma foto de como está atualmente o arquivo após a execução do script
![image](https://github.com/user-attachments/assets/701afdb1-959c-436c-adf8-7827ff3ea339)


